### PR TITLE
Plan: UI discoverability pass (Experiments panel)

### DIFF
--- a/AI-Car-Racer/archive/hash.js
+++ b/AI-Car-Racer/archive/hash.js
@@ -79,3 +79,9 @@ export function hashBrain(flat, seed = 0) {
   const h = xxHash32Bytes(bytes, seed);
   return h.toString(16).padStart(8, '0');
 }
+
+// Symmetric alias: the same xxHash32-over-Float32Array function is used to
+// content-address brains (Phase 1D) AND tracks (Phase A fastlap-track-aware).
+// "hashBrain" reads naturally for the F5 dedup site; "hashVec" reads naturally
+// at the track-fastlap site. Same code, two domain-honest names.
+export const hashVec = hashBrain;

--- a/AI-Car-Racer/buttonResponse.js
+++ b/AI-Car-Racer/buttonResponse.js
@@ -87,6 +87,158 @@ function restoreOldBrain(){
     localStorage.setItem("bestBrain", localStorage.getItem("oldBestBrain"));
     restartBatch();
 }
+
+// === Phase A — named brain saves (multi-slot localStorage) =================
+//
+// Mirrors the single-slot save()/restoreOldBrain() pair above but with
+// arbitrary user-named slots, keyed under `vv_brainsave_<name>`. Each slot
+// stores the same shape as serializeBrain(bestCar.brain) plus light meta
+// (fitness, savedAt, optional trackId/generation) for the dropdown label.
+//
+// Load reuses the existing seeding pathway: write to localStorage.bestBrain
+// + restartBatch(), exactly like restoreOldBrain. Start-fresh wipes every
+// piece of trained state — IDB archive via bridge._debugReset(), the
+// localStorage prior, the lap timer — and reloads.
+const BRAIN_SAVE_PREFIX = "vv_brainsave_";
+
+function _brainSavesList(){
+    var out = [];
+    for (var i = 0; i < localStorage.length; i++){
+        var k = localStorage.key(i);
+        if (k && k.indexOf(BRAIN_SAVE_PREFIX) === 0){
+            out.push(k.slice(BRAIN_SAVE_PREFIX.length));
+        }
+    }
+    out.sort();
+    return out;
+}
+function refreshBrainSavesDropdown(selectedName){
+    var sel = document.getElementById("brainSavesSelect");
+    if (!sel) return;
+    var names = _brainSavesList();
+    sel.innerHTML = "";
+    if (names.length === 0){
+        var opt = document.createElement("option");
+        opt.value = "";
+        opt.textContent = "(no saves yet)";
+        opt.disabled = true;
+        opt.selected = true;
+        sel.appendChild(opt);
+        return;
+    }
+    for (var i = 0; i < names.length; i++){
+        var n = names[i];
+        var opt2 = document.createElement("option");
+        opt2.value = n;
+        // Decorate the label with fitness if we can read it cheaply.
+        var label = n;
+        try {
+            var raw = localStorage.getItem(BRAIN_SAVE_PREFIX + n);
+            if (raw){
+                var slot = JSON.parse(raw);
+                if (slot && typeof slot.fitness === "number"){
+                    label += "  (fit " + slot.fitness.toFixed(1) + ")";
+                }
+            }
+        } catch (_) {}
+        opt2.textContent = label;
+        if (selectedName && n === selectedName) opt2.selected = true;
+        sel.appendChild(opt2);
+    }
+}
+function brainSaveAs(){
+    if (typeof bestCar === "undefined" || !bestCar || !bestCar.brain){
+        window.alert("No best brain to save yet — train at least one generation first.");
+        return;
+    }
+    // Default name: timestamp-fitness, e.g. "2026-04-24-1830-fit42". The user
+    // can rename freely; only the prompt response is used as the key.
+    var fit = Number(window.__rvSessionBestFitness) || 0;
+    var ts = new Date().toISOString().replace(/[:T]/g, "-").slice(0, 16);
+    var defaultName = ts + "-fit" + fit.toFixed(0);
+    var name = (window.prompt("Name this saved brain:", defaultName) || "").trim();
+    if (!name) return;
+    if (localStorage.getItem(BRAIN_SAVE_PREFIX + name)){
+        if (!window.confirm('"' + name + '" already exists. Overwrite?')) return;
+    }
+    var slot = {
+        name: name,
+        savedAt: new Date().toISOString(),
+        fitness: fit,
+        // Optional context — used only for dropdown labels and inspection.
+        // Best-effort; missing fields don't break anything.
+        trackId: (window.lastEmbeddedTrackId || null),
+        // serializeBrain is a global from main.js; its output is the shape
+        // localStorage.bestBrain expects, so Load is a one-line copy.
+        brain: serializeBrain(bestCar.brain),
+    };
+    localStorage.setItem(BRAIN_SAVE_PREFIX + name, JSON.stringify(slot));
+    refreshBrainSavesDropdown(name);
+}
+function brainSaveLoad(){
+    var sel = document.getElementById("brainSavesSelect");
+    var name = sel && sel.value;
+    if (!name){ window.alert("Pick a saved brain from the dropdown first."); return; }
+    var raw = localStorage.getItem(BRAIN_SAVE_PREFIX + name);
+    if (!raw){ window.alert('Saved brain "' + name + '" not found.'); refreshBrainSavesDropdown(); return; }
+    var slot;
+    try { slot = JSON.parse(raw); } catch (_) {
+        window.alert('Saved brain "' + name + '" is corrupted.');
+        return;
+    }
+    if (!slot || !slot.brain){
+        window.alert('Saved brain "' + name + '" is empty.');
+        return;
+    }
+    var ok = window.confirm(
+        'Load "' + name + '"?\n\n' +
+        'This will REPLACE the current best brain with the saved one and ' +
+        'restart the batch.\n\nProceed?'
+    );
+    if (!ok) return;
+    // Mirror restoreOldBrain: write to bestBrain, restart. The seeding
+    // loop in main.js reads localStorage.bestBrain when the batch begins.
+    localStorage.setItem("bestBrain", JSON.stringify(slot.brain));
+    if (typeof restartBatch === "function") restartBatch();
+}
+function brainSaveDelete(){
+    var sel = document.getElementById("brainSavesSelect");
+    var name = sel && sel.value;
+    if (!name) return;
+    if (!window.confirm('Delete saved brain "' + name + '"? This cannot be undone.')) return;
+    localStorage.removeItem(BRAIN_SAVE_PREFIX + name);
+    refreshBrainSavesDropdown();
+}
+async function brainStartFresh(){
+    var ok = window.confirm(
+        "Start with an empty brain?\n\n" +
+        "This will WIPE everything trained so far:\n" +
+        " • the live archive (all archived brains, tracks, dynamics)\n" +
+        " • the saved best brain + fast lap\n" +
+        " • the lineage DAG\n" +
+        "\n" +
+        "Your named brain saves are NOT deleted (use Delete for those).\n" +
+        "The page will reload. Proceed?"
+    );
+    if (!ok) return;
+    // Wipe IDB + bridge in-memory state via bridge._debugReset(). The
+    // bridge surfaces this on window for the verifier console; we use the
+    // same hook here.
+    try {
+        if (window.__rvBridge && typeof window.__rvBridge._debugReset === "function"){
+            await window.__rvBridge._debugReset();
+        }
+    } catch (e) { console.warn("[brain-saves] _debugReset failed", e); }
+    // Wipe legacy localStorage trained state. Named saves
+    // (vv_brainsave_*) are deliberately preserved so a fresh-start
+    // doesn't lose the user's curated slots.
+    var legacyKeys = ["bestBrain", "oldBestBrain", "fastLap", "progress", "rvAnnotations"];
+    for (var i = 0; i < legacyKeys.length; i++){
+        try { localStorage.removeItem(legacyKeys[i]); } catch (_) {}
+    }
+    location.reload();
+}
+// =========================================================================
 function resetFastLap(){
     fastLap = '--';
 }

--- a/AI-Car-Racer/buttonResponse.js
+++ b/AI-Car-Racer/buttonResponse.js
@@ -240,12 +240,65 @@ async function brainStartFresh(){
 }
 // =========================================================================
 function resetFastLap(){
+    // Phase A: scope the reset to the CURRENT track only. The legacy
+    // global `localStorage.fastLap` key was retired at boot; the new
+    // per-track keys are vv_fastlap_<trackHash>. Use the bridge helper
+    // exposed by main.js to look up the current track's key.
+    try {
+        if (window.__vvFastLap && typeof window.__vvFastLap.trackKey === 'function') {
+            const k = window.__vvFastLap.trackKey();
+            if (k) localStorage.removeItem(k);
+            // Re-sync the global cache so the UI reflects the cleared state.
+            if (typeof window.__vvFastLap.syncFromStore === 'function') {
+                window.__vvFastLap.syncFromStore();
+                return;
+            }
+        }
+    } catch (_) {}
+    // Fallback for the case where the bridge helper isn't loaded yet
+    // (e.g., during very early boot). Match the pre-Phase-A behaviour
+    // of clearing the in-memory cache.
     fastLap = '--';
+    if (typeof lastLap !== 'undefined') lastLap = null;
 }
 function destroyBrain(){
     localStorage.removeItem("bestBrain");
+    // Phase A: legacy fastLap key is already retired at boot; this
+    // removal is a no-op now but kept so any pre-Phase-A revert leaves
+    // a clean slate. resetFastLap() handles the per-track keys.
     localStorage.removeItem("fastLap");
-    fastLap="--";
+    resetFastLap();
+}
+
+// Phase A: bulk clear of every per-track fastLap. Wired from the
+// 🧠 Brain saves disclosure (utils.js) for the destructive bulk option,
+// distinct from resetFastLap() which only clears the current track.
+function clearAllFastLaps(){
+    var keys = [];
+    try {
+        for (var i = 0; i < localStorage.length; i++){
+            var k = localStorage.key(i);
+            if (k && window.__vvFastLap && k.indexOf(window.__vvFastLap.prefix) === 0){
+                keys.push(k);
+            }
+        }
+    } catch (_) {}
+    if (keys.length === 0){
+        window.alert('No fast-lap records to clear.');
+        return;
+    }
+    if (!window.confirm('Clear ALL ' + keys.length + ' track fast-lap record' +
+                        (keys.length === 1 ? '' : 's') +
+                        '? This cannot be undone.\n\nNamed brain saves are NOT affected.')){
+        return;
+    }
+    for (var j = 0; j < keys.length; j++) localStorage.removeItem(keys[j]);
+    // Resync display.
+    try {
+        if (window.__vvFastLap && typeof window.__vvFastLap.syncFromStore === 'function'){
+            window.__vvFastLap.syncFromStore();
+        }
+    } catch (_) {}
 }
 function submitTrack(){
     road.getTrack();

--- a/AI-Car-Racer/main.js
+++ b/AI-Car-Racer/main.js
@@ -93,7 +93,140 @@ var invincible=false;
 var traction=0.5;
 
 var frameCount = 0;                // mirrors worker's frameCount via snapshots
+
+// === Phase A — track-aware fast lap =====================================
+// Three pieces of state, all globals because main.js is a classic script
+// and other classic-script files (buttonResponse.js, brainExport.js) read
+// `fastLap` directly. We KEEP `fastLap` as a global cache of the *current
+// track's* best lap so existing callers continue to work; we just resync
+// it whenever the active track changes (see _syncFastLapForCurrentTrack).
+//
+// Storage shape: localStorage.vv_fastlap_<trackHash> = JSON of
+// { timeS, recordedAt, generation }. trackHash is xxHash32 of the 512-d
+// CNN track embedding (window.currentTrackVec) — same Phase 0 hash util
+// that content-addresses brains; Phase A re-uses it under the alias
+// hashVec for naming honesty.
+//
+// `lastLap` is in-memory only: it tracks the most recent *completed* lap
+// in this session, regardless of whether it was a record. Persisting
+// "last" would conflate it with "fastest"; the value of last-lap is
+// real-time signal during a run, not historical.
+//
+// `allTimeBest` is a derived cache: min over every vv_fastlap_* entry.
+// Recomputed on track change and on new-record. Cheap (small N).
 var fastLap = '--';
+var lastLap = null;
+var allTimeBest = null;
+const FASTLAP_PREFIX = 'vv_fastlap_';
+
+// Async-load the hash util once. main.js is a classic script; archive/hash.js
+// is an ES module — dynamic import() bridges them. Until it resolves,
+// _trackHash() returns null and the fast-lap logic falls back to '--' (no
+// regression vs. pre-Phase-A: the legacy global was '--' on first load too).
+let __hashVec = null;
+import('./archive/hash.js').then((m) => { __hashVec = m.hashVec || m.hashBrain; })
+    .catch((e) => { console.warn('[fastlap] hash util load failed', e); });
+
+// Track-hash cache so we don't re-xxHash the 512-dim vec on every render.
+let __trackHashCache = { vec: null, hash: null };
+function _trackHash() {
+    const v = window.currentTrackVec;
+    if (!v || !v.length || !__hashVec) return null;
+    if (__trackHashCache.vec === v) return __trackHashCache.hash;
+    try {
+        const h = __hashVec(v);
+        __trackHashCache = { vec: v, hash: h };
+        return h;
+    } catch (e) {
+        console.warn('[fastlap] hash failed', e);
+        return null;
+    }
+}
+function _trackKey() {
+    const h = _trackHash();
+    return h ? (FASTLAP_PREFIX + h) : null;
+}
+function _readFastLapForCurrentTrack() {
+    const key = _trackKey();
+    if (!key) return '--';
+    try {
+        const raw = localStorage.getItem(key);
+        if (!raw) return '--';
+        const obj = JSON.parse(raw);
+        return (typeof obj.timeS === 'number') ? obj.timeS : '--';
+    } catch (_) { return '--'; }
+}
+function _writeFastLapForCurrentTrack(timeS, generation) {
+    const key = _trackKey();
+    if (!key) return false;
+    try {
+        localStorage.setItem(key, JSON.stringify({
+            timeS: timeS,
+            recordedAt: new Date().toISOString(),
+            generation: (generation | 0),
+        }));
+        return true;
+    } catch (e) {
+        console.warn('[fastlap] write failed', e);
+        return false;
+    }
+}
+function _computeAllTimeBest() {
+    let best = Infinity;
+    try {
+        for (let i = 0; i < localStorage.length; i++) {
+            const k = localStorage.key(i);
+            if (!k || k.indexOf(FASTLAP_PREFIX) !== 0) continue;
+            try {
+                const obj = JSON.parse(localStorage.getItem(k));
+                if (obj && typeof obj.timeS === 'number' && obj.timeS < best) best = obj.timeS;
+            } catch (_) {}
+        }
+    } catch (_) {}
+    return Number.isFinite(best) ? best : null;
+}
+// Re-sync the global cache from localStorage. Called on boot (after the
+// hash util loads), on track change, on reset, and after a new-record write.
+function _syncFastLapForCurrentTrack() {
+    fastLap = _readFastLapForCurrentTrack();
+    allTimeBest = _computeAllTimeBest();
+}
+// Exposed on window so buttonResponse.js (classic script, separate file)
+// can call them without a module bridge. Kept namespaced under __vvFastLap
+// so we don't pollute the global namespace beyond `fastLap` itself.
+window.__vvFastLap = {
+    syncFromStore: _syncFastLapForCurrentTrack,
+    write: _writeFastLapForCurrentTrack,
+    read: _readFastLapForCurrentTrack,
+    trackKey: _trackKey,
+    allTimeBest: _computeAllTimeBest,
+    setLastLap: function (t) { lastLap = (typeof t === 'number') ? t : null; },
+    getLastLap: function () { return lastLap; },
+    prefix: FASTLAP_PREFIX,
+};
+
+// Legacy retirement: silently drop the pre-Phase-A track-confused
+// localStorage.fastLap key. The old value was attributed to no specific
+// track, so migrating it would be misleading; clean cut is honest.
+try { localStorage.removeItem('fastLap'); } catch (_) {}
+
+// Polling boot-sync: when the hash util eventually loads AND
+// currentTrackVec eventually becomes available, sync the cache so the
+// timer renders the right number on the very first paint that has both.
+// Bounded retries; gives up silently if neither materializes (display
+// stays '--' which is the correct "no record on this track yet" state).
+(function _bootSyncFastLap() {
+    let tries = 0;
+    const id = setInterval(() => {
+        if (__hashVec && window.currentTrackVec) {
+            _syncFastLapForCurrentTrack();
+            clearInterval(id);
+        } else if (++tries > 60) {
+            clearInterval(id);
+        }
+    }, 250);
+})();
+// =========================================================================
 
 // Sim-speed multiplier. Worker owns the AI-car accumulator; main owns a
 // parallel accumulator for the 2 player cars only. They drift slightly under
@@ -145,9 +278,10 @@ if (localStorage.getItem("traction")){
 if (localStorage.getItem("maxSpeed")){
     maxSpeed=JSON.parse(localStorage.getItem("maxSpeed"));
 }
-if (localStorage.getItem("fastLap")){
-    fastLap = JSON.parse(localStorage.getItem("fastLap"));
-}
+// Phase A: legacy `fastLap` localStorage key retired in the boot block
+// above; per-track values now live under vv_fastlap_<trackHash>. The
+// initial hydration from those keys happens in _bootSyncFastLap() once
+// both the hash util and currentTrackVec are available.
 if (localStorage.getItem("conservativeInit")){
     const v = parseFloat(localStorage.getItem("conservativeInit"));
     if (Number.isFinite(v)) conservativeInit = Math.max(0, Math.min(1, v));
@@ -1126,9 +1260,21 @@ function performNextBatch(genData){
     _times.save = performance.now() - _tSave;
     if (genData.laps > 0 && genData.lapTimes && genData.lapTimes.length){
         const minLap = Math.min.apply(null, genData.lapTimes);
+        // Phase A: lastLap is "the most recent completed lap", not the
+        // batch's fastest. Multi-lap batches still update lastLap to the
+        // last entry for an honest "what just happened?" signal.
+        const lastEntry = genData.lapTimes[genData.lapTimes.length - 1];
+        if (typeof lastEntry === 'number' && Number.isFinite(lastEntry)) {
+            lastLap = lastEntry;
+        }
         if (fastLap === '--' || minLap < fastLap){
+            // Per-track write. _writeFastLapForCurrentTrack is a no-op if
+            // currentTrackVec/hash aren't ready yet; the in-memory
+            // `fastLap` cache still updates so the UI reflects the new
+            // record even if the persist is deferred to the next sync.
             fastLap = minLap;
-            localStorage.setItem('fastLap', JSON.stringify(fastLap));
+            _writeFastLapForCurrentTrack(minLap, generation);
+            allTimeBest = _computeAllTimeBest();
         }
     }
 
@@ -1233,7 +1379,25 @@ function animate(){
         const wallSecs = ((performance.now() - wallStart)/1000).toFixed(2);
         timer.innerHTML = "<p>Sim Time: " + simSecs + "s " +
             "<span style='opacity:.65;font-size:.85em'>(wall " + wallSecs + "s &middot; " + simSpeed + "&times;)</span></p>";
-        timer.innerHTML += "<p>Fast Lap: " + (typeof fastLap === 'number' ? fastLap.toFixed(2) : fastLap) + "</p>";
+        // Phase A: track-aware fast-lap render. Three lines:
+        //   • Fast Lap: 12.34s (this track)
+        //   • Last:     14.10s
+        //   • all-time best: 9.10s
+        // The "(this track)" tag is load-bearing — without it a returning
+        // user could assume the displayed value is global. allTimeBest is
+        // hidden when only one track has ever been raced (best === current).
+        const _fastStr = (typeof fastLap === 'number' ? fastLap.toFixed(2) + 's' : fastLap);
+        const _lastStr = (typeof lastLap === 'number' ? lastLap.toFixed(2) + 's' : '—');
+        timer.innerHTML += "<p>Fast Lap: " + _fastStr +
+            " <span style='opacity:.55;font-size:.85em'>(this track)</span></p>";
+        timer.innerHTML += "<p style='opacity:.85'>Last: " + _lastStr + "</p>";
+        if (typeof allTimeBest === 'number' &&
+            (typeof fastLap !== 'number' || allTimeBest < fastLap)) {
+            // Only show the subscript when a different track holds the
+            // record — saves a row of noise for single-track users.
+            timer.innerHTML += "<p style='opacity:.55;font-size:.82em;margin-top:-4px'>" +
+                "all-time best: " + allTimeBest.toFixed(2) + "s</p>";
+        }
         ctx.save();
 
         if(!pause){

--- a/AI-Car-Racer/style.css
+++ b/AI-Car-Racer/style.css
@@ -2217,3 +2217,68 @@ label {
     font-weight: 600;
     letter-spacing: 0.02em;
 }
+
+/* === Phase A — Brain saves (named-slot persistence) === */
+/* Mounted directly below the legacy Save Best + Restart actions, so the
+ * single-slot legacy buttons and the multi-slot named saves are
+ * visually adjacent. Native <details>/<summary> for the disclosure. */
+.brain-saves {
+    margin-top: 10px;
+    padding: 8px 10px;
+    background: rgba(20, 28, 48, 0.55);
+    border: 1px solid rgba(120, 140, 200, 0.18);
+    border-radius: 6px;
+}
+.brain-saves > summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #cbd8ff;
+    user-select: none;
+    list-style: none;
+    padding: 2px 0;
+}
+.brain-saves > summary::-webkit-details-marker { display: none; }
+.brain-saves > summary::before {
+    content: '▸';
+    display: inline-block;
+    margin-right: 6px;
+    transition: transform 120ms ease-out;
+}
+.brain-saves[open] > summary::before { transform: rotate(90deg); }
+.brain-saves-hint {
+    font-weight: 400;
+    color: #8a98be;
+    font-size: 0.85em;
+    margin-left: 6px;
+}
+.brain-saves-body {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.brain-saves-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: stretch;
+}
+.brain-saves-select {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 4px 8px;
+    background: rgba(10, 16, 32, 0.85);
+    color: #e6ebfa;
+    border: 1px solid rgba(120, 140, 200, 0.32);
+    border-radius: 4px;
+    font: inherit;
+}
+.brain-saves-fresh {
+    /* Make Start Fresh visually distinct so users don't confuse it with
+     * the cheaper Reset Brain. Soft amber tint = "destructive but
+     * not catastrophic." Confirm dialog still gates execution. */
+    background: rgba(180, 110, 60, 0.20) !important;
+    border-color: rgba(200, 130, 75, 0.45) !important;
+    color: #f0d6b6 !important;
+}
+.brain-saves-fresh:hover { background: rgba(180, 110, 60, 0.32) !important; }

--- a/AI-Car-Racer/style.css
+++ b/AI-Car-Racer/style.css
@@ -2117,3 +2117,103 @@ label {
     0%   { background: #62f0b8; box-shadow: 0 0 10px rgba(98, 240, 184, 0.65); }
     100% { background: rgba(98, 240, 184, 0.14); box-shadow: 0 0 0 rgba(0, 0, 0, 0); }
 }
+
+/* === Phase A — Experiments disclosure panel === */
+/* Consolidates RuLake-inspired feature toggles. Native <details> +
+ * <summary> for the disclosure — no JS animation, no custom widget. */
+.rv-experiments {
+    margin-top: 14px;
+    padding: 8px 10px;
+    background: rgba(20, 28, 48, 0.55);
+    border: 1px solid rgba(120, 140, 200, 0.18);
+    border-radius: 6px;
+}
+.rv-experiments[open] {
+    background: rgba(20, 28, 48, 0.75);
+}
+.rv-experiments-summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #cbd8ff;
+    user-select: none;
+    list-style: none;
+    padding: 2px 0;
+}
+.rv-experiments-summary::-webkit-details-marker { display: none; }
+.rv-experiments-summary::before {
+    content: '▸';
+    display: inline-block;
+    margin-right: 6px;
+    transition: transform 120ms ease-out;
+}
+.rv-experiments[open] .rv-experiments-summary::before {
+    transform: rotate(90deg);
+}
+.rv-experiments-hint {
+    font-weight: 400;
+    color: #8a98be;
+    font-size: 0.85em;
+    margin-left: 6px;
+}
+.rv-experiments-body {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.rv-experiments-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px 10px;
+    padding: 4px 6px;
+    border-radius: 4px;
+}
+.rv-experiments-row + .rv-experiments-row {
+    border-top: 1px solid rgba(120, 140, 200, 0.08);
+    padding-top: 8px;
+}
+.rv-experiments-row > [data-rv]:not(input):not(label) {
+    /* migrated rows (consistency, federation, crosstab) keep their own
+     * layouts — strip the row's wrap so they read clean inside */
+    flex: 1 1 100%;
+}
+.rv-experiments-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    color: #e6ebfa;
+}
+.rv-experiments-toggle input[type="checkbox"] { cursor: pointer; }
+.rv-experiments-emoji { font-size: 1.05em; }
+.rv-experiments-label { font-weight: 500; }
+.rv-experiments-hint-inline {
+    color: #8a98be;
+    font-size: 0.85em;
+    font-style: italic;
+}
+.rv-experiments-subbody {
+    flex: 1 1 100%;
+    margin-top: 4px;
+    padding: 6px 8px;
+    background: rgba(10, 16, 32, 0.45);
+    border-radius: 4px;
+}
+.rv-experiments-subbody[hidden] { display: none; }
+
+/* Disabled (library-only) row styling */
+.rv-experiments-row-disabled { opacity: 0.55; }
+.rv-experiments-toggle-disabled { cursor: not-allowed; }
+.rv-experiments-toggle-disabled input { cursor: not-allowed; }
+.rv-experiments-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    margin-left: 4px;
+    border-radius: 3px;
+    background: rgba(180, 140, 90, 0.22);
+    color: #d8c39a;
+    font-size: 0.75em;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}

--- a/AI-Car-Racer/uiPanels.js
+++ b/AI-Car-Racer/uiPanels.js
@@ -241,17 +241,24 @@
     '</div>',
   ].join('');
 
-  // Phase 1A (F3). Warm-restart archive Export/Import row — rendered ONLY
-  // when the URL has ?snapshots=1 so the default experience is unchanged
-  // while the feature is baking. The row is a plain DOM append (not baked
-  // into the innerHTML above) so the gate lives in one readable place.
-  let _snapshotsFlagOn = false;
-  try {
-    if (typeof URLSearchParams === 'function') {
-      _snapshotsFlagOn = new URLSearchParams(window.location.search || '').get('snapshots') === '1';
-    }
-  } catch (_) { _snapshotsFlagOn = false; }
-  if (_snapshotsFlagOn) {
+  // Phase 1A (F3). Warm-restart archive Export/Import row.
+  //
+  // Phase A (UI discoverability pass): the row is now ALWAYS created. The
+  // ?snapshots=1 URL flag is preserved, but it presets the "Save & share
+  // archives" toggle inside the 🧪 Experiments disclosure rather than gating
+  // whether this DOM ever exists. The Experiments wrapper at the bottom of
+  // this file moves this row into the disclosure body and hides it until the
+  // user (or the URL flag) opts in.
+  const _snapshotsFlagOn = (function () {
+    try {
+      if (typeof URLSearchParams === 'function') {
+        return new URLSearchParams(window.location.search || '').get('snapshots') === '1';
+      }
+    } catch (_) {}
+    return false;
+  })();
+  let __rvSnapshotsRow = null;
+  {
     const row = document.createElement('div');
     row.className = 'rv-snapshots';
     row.setAttribute('data-rv', 'snapshots');
@@ -309,7 +316,23 @@
       }
     });
 
-    btnImport.addEventListener('click', function () { fileInput.click(); });
+    btnImport.addEventListener('click', function () {
+      // Phase A guardrail — Import REPLACES the live archive. With the
+      // ?snapshots=1 URL flag retired as a friction layer, the confirm()
+      // is what stops an accidental click from wiping a long training run.
+      const b = window.__rvBridge;
+      const liveCount = (function () {
+        try { return (b && b.info && b.info().brains) | 0; } catch (_) { return 0; }
+      })();
+      const ok = window.confirm(
+        'Import archive bundle?\n\n' +
+        'This will REPLACE your current archive (' + liveCount + ' brain' +
+        (liveCount === 1 ? '' : 's') + ') with the contents of the imported file.\n\n' +
+        'Proceed?'
+      );
+      if (!ok) return;
+      fileInput.click();
+    });
     fileInput.addEventListener('change', async function () {
       const file = fileInput.files && fileInput.files[0];
       if (!file) return;
@@ -335,6 +358,7 @@
         fileInput.value = '';
       }
     });
+    __rvSnapshotsRow = row;
   }
 
   const el = {
@@ -503,19 +527,14 @@
       if (on) await ensureFederationViewer();
     });
   }
-  // Phase 2B (F6) — cross-tab pill. Visible only when ?crosstab=1 URL flag is
-  // present (feature is baking behind a flag). Subscribes to the bridge's
-  // setCrosstabListeners so we get a callback on every received remote brain
-  // (for the green pulse) and on peer-count changes (for the "N peer(s)"
-  // readout). The subscription attempt is best-effort and retries a few
-  // times because the bridge sidecar can land slightly after the panel.
-  let _crosstabFlagOn = false;
-  try {
-    if (typeof URLSearchParams === 'function') {
-      _crosstabFlagOn = new URLSearchParams(window.location.search || '').get('crosstab') === '1';
-    }
-  } catch (_) { _crosstabFlagOn = false; }
-  if (el.crosstab && _crosstabFlagOn) el.crosstab.hidden = false;
+  // Phase 2B (F6) — cross-tab pill. Phase A (UI discoverability pass):
+  // visibility now belongs to the Experiments disclosure's "Cross-tab live
+  // training" toggle, which also flips bridge.setCrosstabEnabled. The pill
+  // element itself (`el.crosstab`) is moved into the disclosure subbody
+  // later in this file; we always wire listeners here so the pulse + peer
+  // count work the moment the user flips the checkbox.
+  // The legacy `?crosstab=1` URL flag is preserved as a preset (it pre-
+  // checks the experiments toggle); see buildExperimentsPanel().
   function renderCrosstabPeers(n) {
     if (!el.crosstabPeers) return;
     const count = Math.max(0, n | 0);
@@ -555,7 +574,9 @@
       }
     }
   }
-  if (_crosstabFlagOn) ensureCrosstabWiring();
+  // Always wire listeners; the experiments toggle gates whether the bridge
+  // actually broadcasts/receives. The pill stays accurate either way.
+  ensureCrosstabWiring();
 
   function renderFederation() {
     const b = window.__rvBridge;
@@ -1432,8 +1453,10 @@
   });
 
   // === Phase 3C share panel ===
-  // Rendered ONLY when `?snapshots=1` is present (same gate as the Phase
-  // 1A Export/Import row above). Three capabilities:
+  // Phase A (UI discoverability pass): always created; visibility is
+  // controlled by the "Save & share archives" toggle inside the Experiments
+  // disclosure. The ?snapshots=1 URL flag is preserved as a preset for that
+  // toggle. Three capabilities (unchanged):
   //   1. "📋 Copy shareable link" — prompts for a URL the user already
   //      hosts the bundle at, copies `?snapshots=1&archive=<url>` to the
   //      clipboard. We host nothing.
@@ -1444,13 +1467,8 @@
   //      (see the external-scope note in gallery.js).
   // The anchor comment above is load-bearing: future phases should mount
   // above/below it, not replace it.
-  let _sharePanelGateOn = false;
-  try {
-    if (typeof URLSearchParams === 'function') {
-      _sharePanelGateOn = new URLSearchParams(window.location.search || '').get('snapshots') === '1';
-    }
-  } catch (_) { _sharePanelGateOn = false; }
-  if (_sharePanelGateOn) {
+  let __rvShareRow = null;
+  {
     const shareRow = document.createElement('div');
     shareRow.className = 'rv-share';
     shareRow.setAttribute('data-rv', 'share');
@@ -1536,16 +1554,209 @@
     });
 
     btnImport.addEventListener('click', function () {
-      __shareImportFromUrl((urlInput.value || '').trim());
+      const url = (urlInput.value || '').trim();
+      if (!url) { setShareStatus('paste a URL above first', 'error'); return; }
+      // Phase A guardrail — same logic as the file-import confirm above.
+      const b = window.__rvBridge;
+      const liveCount = (function () {
+        try { return (b && b.info && b.info().brains) | 0; } catch (_) { return 0; }
+      })();
+      const ok = window.confirm(
+        'Import archive from URL?\n\n' +
+        url + '\n\n' +
+        'This will REPLACE your current archive (' + liveCount + ' brain' +
+        (liveCount === 1 ? '' : 's') + ').\n\nProceed?'
+      );
+      if (!ok) return;
+      __shareImportFromUrl(url);
     });
 
     // Mount the community gallery. Each entry's button routes back
     // through the same fetch+import flow as the "📎 Import from URL"
-    // button so the UX is consistent.
+    // button so the UX is consistent. The gallery handler also goes
+    // through confirm() because the placeholder will eventually become
+    // real third-party URLs.
     import('./share/gallery.js').then(({ mountGalleryPanel }) => {
-      mountGalleryPanel(galleryMount, (url) => __shareImportFromUrl(url));
+      mountGalleryPanel(galleryMount, (url) => {
+        const b = window.__rvBridge;
+        const liveCount = (function () {
+          try { return (b && b.info && b.info().brains) | 0; } catch (_) { return 0; }
+        })();
+        const ok = window.confirm(
+          'Import this community archive?\n\n' + url + '\n\n' +
+          'This will REPLACE your current archive (' + liveCount + ' brain' +
+          (liveCount === 1 ? '' : 's') + ').\n\nProceed?'
+        );
+        if (!ok) return;
+        __shareImportFromUrl(url);
+      });
     }).catch((e) => {
       console.warn('[rv-panel] share gallery mount failed', e);
     });
+    __rvShareRow = shareRow;
   }
+
+  // === Phase A — UI discoverability pass: 🧪 Experiments disclosure ===
+  //
+  // Consolidates the RuLake-inspired feature toggles into one collapsible
+  // section. The previously-flag-gated rows (snapshots, share, crosstab)
+  // now live here and are gated by checkboxes inside the disclosure. URL
+  // flags are preserved as PRESETS that pre-toggle the corresponding
+  // checkbox at boot, but they no longer gate whether the UI exists.
+  //
+  // We MOVE existing DOM nodes (consistency, federation, crosstab,
+  // snapshots, share) into the disclosure body via appendChild, which
+  // preserves every existing event listener and querySelector reference.
+  // Refactoring all that wiring would be a much bigger change; the move-
+  // not-rebuild approach is the smallest possible diff that achieves the
+  // discoverability goal.
+  //
+  // Default state: see the "Default state per feature" table in
+  // docs/plan/ui-discoverability-pass.md.
+  (function buildExperimentsPanel() {
+    const usp = (function () {
+      try { return new URLSearchParams(window.location.search || ''); } catch (_) { return null; }
+    })();
+    const flag = (k) => usp && usp.get(k) !== null;
+    const flagEq = (k, v) => usp && usp.get(k) === v;
+
+    const details = document.createElement('details');
+    details.className = 'rv-experiments';
+    details.setAttribute('data-rv', 'experiments');
+    details.innerHTML = [
+      '<summary class="rv-experiments-summary">🧪 Experiments <span class="rv-experiments-hint">(RuLake-inspired toggles)</span></summary>',
+      '<div class="rv-experiments-body" data-rv="experiments-body">',
+      '  <div class="rv-experiments-row" data-rv="exp-observability-row">',
+      '    <label class="rv-experiments-toggle">',
+      '      <input type="checkbox" data-rv="exp-observability" checked />',
+      '      <span class="rv-experiments-emoji">⏱</span>',
+      '      <span class="rv-experiments-label">Per-stage timings panel</span>',
+      '    </label>',
+      '    <span class="rv-experiments-hint-inline">flame-graph-lite for every generation</span>',
+      '    <span data-eli15="where-the-time-goes" role="button" tabindex="0" aria-label="Learn: where the time goes"></span>',
+      '  </div>',
+      '  <div class="rv-experiments-row" data-rv="exp-snapshots-row">',
+      '    <label class="rv-experiments-toggle">',
+      '      <input type="checkbox" data-rv="exp-snapshots" />',
+      '      <span class="rv-experiments-emoji">📦</span>',
+      '      <span class="rv-experiments-label">Save &amp; share archives</span>',
+      '    </label>',
+      '    <span class="rv-experiments-hint-inline">export, import, share via URL</span>',
+      '    <span data-eli15="warm-restart" role="button" tabindex="0" aria-label="Learn: warm-restart bundles"></span>',
+      '    <div class="rv-experiments-subbody" data-rv="exp-snapshots-subbody" hidden></div>',
+      '  </div>',
+      '  <div class="rv-experiments-row" data-rv="exp-crosstab-row">',
+      '    <label class="rv-experiments-toggle">',
+      '      <input type="checkbox" data-rv="exp-crosstab" />',
+      '      <span class="rv-experiments-emoji">🔗</span>',
+      '      <span class="rv-experiments-label">Cross-tab live training</span>',
+      '    </label>',
+      '    <span class="rv-experiments-hint-inline">two tabs share an archive via BroadcastChannel</span>',
+      '    <span data-eli15="cross-tab-federation" role="button" tabindex="0" aria-label="Learn: cross-tab live training"></span>',
+      '    <div class="rv-experiments-subbody" data-rv="exp-crosstab-subbody" hidden></div>',
+      '  </div>',
+      '  <div class="rv-experiments-row" data-rv="exp-federation-row"></div>',
+      '  <div class="rv-experiments-row" data-rv="exp-consistency-row"></div>',
+      '  <div class="rv-experiments-row rv-experiments-row-disabled" data-rv="exp-quantization-row" title="Library-only — not wired into archiveBrain yet. See the chapter for details.">',
+      '    <label class="rv-experiments-toggle rv-experiments-toggle-disabled">',
+      '      <input type="checkbox" disabled />',
+      '      <span class="rv-experiments-emoji">📐</span>',
+      '      <span class="rv-experiments-label">1-bit quantized archive</span>',
+      '      <span class="rv-experiments-badge">library-only</span>',
+      '    </label>',
+      '    <span class="rv-experiments-hint-inline">module ships, integration is a future slice</span>',
+      '    <span data-eli15="quantization" role="button" tabindex="0" aria-label="Learn: 1-bit quantization"></span>',
+      '  </div>',
+      '</div>',
+    ].join('');
+    root.appendChild(details);
+
+    const expBody = details.querySelector('[data-rv="experiments-body"]');
+    const expSnapshotsRow = details.querySelector('[data-rv="exp-snapshots-row"]');
+    const expSnapshotsCb = details.querySelector('[data-rv="exp-snapshots"]');
+    const expSnapshotsSub = details.querySelector('[data-rv="exp-snapshots-subbody"]');
+    const expCrosstabRow = details.querySelector('[data-rv="exp-crosstab-row"]');
+    const expCrosstabCb = details.querySelector('[data-rv="exp-crosstab"]');
+    const expCrosstabSub = details.querySelector('[data-rv="exp-crosstab-subbody"]');
+    const expFedRow = details.querySelector('[data-rv="exp-federation-row"]');
+    const expConsRow = details.querySelector('[data-rv="exp-consistency-row"]');
+    const expObsCb = details.querySelector('[data-rv="exp-observability"]');
+
+    // Move existing DOM nodes into the disclosure. Listeners attached
+    // earlier survive the appendChild move — that's the whole reason we
+    // refactored as "wrap, don't rebuild."
+    const consistencyEl = root.querySelector('[data-rv="consistency"]');
+    const federationEl = root.querySelector('[data-rv="federation"]');
+    const crosstabEl = root.querySelector('[data-rv="crosstab"]');
+    if (federationEl && expFedRow) {
+      // Unset the federation toggle's prior placement; re-parent under exp.
+      expFedRow.appendChild(federationEl);
+    }
+    if (consistencyEl && expConsRow) {
+      expConsRow.appendChild(consistencyEl);
+    }
+    if (crosstabEl && expCrosstabSub) {
+      // The pill itself moves into the snapshots-style subbody, hidden
+      // until the experiments checkbox flips it on.
+      crosstabEl.hidden = false; // we control via subbody.hidden now
+      expCrosstabSub.appendChild(crosstabEl);
+    }
+    if (__rvSnapshotsRow && expSnapshotsSub) {
+      expSnapshotsSub.appendChild(__rvSnapshotsRow);
+    }
+    if (__rvShareRow && expSnapshotsSub) {
+      expSnapshotsSub.appendChild(__rvShareRow);
+    }
+
+    // Snapshots toggle — show/hide the controls (which include both the
+    // file-based Export/Import row and the URL share row).
+    function applySnapshotsState(on) {
+      if (!expSnapshotsSub) return;
+      expSnapshotsSub.hidden = !on;
+    }
+    expSnapshotsCb.addEventListener('change', () => applySnapshotsState(expSnapshotsCb.checked));
+    if (_snapshotsFlagOn) {
+      expSnapshotsCb.checked = true;
+      applySnapshotsState(true);
+    }
+
+    // Crosstab toggle — flip both the bridge state AND the pill visibility.
+    function applyCrosstabState(on) {
+      if (expCrosstabSub) expCrosstabSub.hidden = !on;
+      try {
+        const b = window.__rvBridge;
+        if (b && typeof b.setCrosstabEnabled === 'function') b.setCrosstabEnabled(!!on);
+      } catch (e) { console.warn('[rv-experiments] setCrosstabEnabled failed', e); }
+    }
+    expCrosstabCb.addEventListener('change', () => applyCrosstabState(expCrosstabCb.checked));
+    // ?crosstab=1 preset — but the bridge may not be ready yet. The
+    // existing __applyUrlCrosstabFlag in main.js polls for bridge
+    // readiness; here we just sync the checkbox state. The bridge's
+    // setCrosstabEnabled will then be called once it's ready.
+    if (flagEq('crosstab', '1')) {
+      expCrosstabCb.checked = true;
+      // Apply with a short delay to give the bridge time to load. If the
+      // bridge isn't ready, applyCrosstabState's try/catch swallows it
+      // and main.js's poll will pick up the slack.
+      setTimeout(() => applyCrosstabState(true), 100);
+    }
+
+    // Observability toggle — show/hide the obs panel. The panel itself is
+    // mounted by the existing 3A code below; we just toggle its CSS.
+    function applyObsState(on) {
+      const obs = root.querySelector('.rv-obs-panel');
+      if (obs) obs.hidden = !on;
+    }
+    expObsCb.addEventListener('change', () => applyObsState(expObsCb.checked));
+    // Apply after a tick so the obs panel is mounted by then.
+    setTimeout(() => applyObsState(expObsCb.checked), 250);
+
+    // Default-collapsed: leave details closed unless any feature is
+    // pre-toggled by a URL flag, in which case open it so the user can
+    // see what their share-link enabled.
+    if (flag('snapshots') || flag('crosstab') || flag('federation') ||
+        flag('consistency') || flag('archive')) {
+      details.open = true;
+    }
+  })();
 })();

--- a/AI-Car-Racer/utils.js
+++ b/AI-Car-Racer/utils.js
@@ -172,6 +172,24 @@ function phaseToLayout(phase){
                     <button class='controlButton' onclick='restoreOldBrain();'>Restore Old Brain</button>
                 </div>
             </details>
+            <details id='brainSaves' class='brain-saves' open>
+                <summary>🧠 Brain saves <span class='brain-saves-hint'>(named slots)</span></summary>
+                <div class='brain-saves-body'>
+                    <div class='brain-saves-row'>
+                        <select id='brainSavesSelect' class='brain-saves-select' aria-label='Saved brain slots'>
+                            <option value='' disabled selected>(no saves yet)</option>
+                        </select>
+                    </div>
+                    <div class='brain-saves-row'>
+                        <button class='controlButton' onclick='brainSaveAs();' title='Save the current best brain under a name you choose'>💾 Save current as…</button>
+                        <button class='controlButton' onclick='brainSaveLoad();' title='Replace the current best brain with the selected saved one and restart the batch'>📂 Load</button>
+                        <button class='controlButton' onclick='brainSaveDelete();' title='Delete the selected saved brain'>🗑 Delete</button>
+                    </div>
+                    <div class='brain-saves-row'>
+                        <button class='controlButton brain-saves-fresh' onclick='brainStartFresh();' title='Wipe ALL trained state (archive + saved best + fast lap) and reload — true gen-0 start. Named saves are preserved.'>🌱 Start with empty brain</button>
+                    </div>
+                </div>
+            </details>
             `;
             bottomText.innerHTML = `
                 <h1>Train your model!</h1>
@@ -189,12 +207,22 @@ function phaseToLayout(phase){
             try {
                 const brainShareEl = document.getElementById('brainShareSection');
                 const moreActionsEl = document.getElementById('moreActions');
+                const brainSavesEl = document.getElementById('brainSaves');
                 const rvPanelEl = document.getElementById('rv-panel');
                 if (rvPanelEl && rvPanelEl.parentNode) {
                     if (brainShareEl) rvPanelEl.parentNode.insertBefore(brainShareEl, rvPanelEl.nextSibling);
                     if (moreActionsEl && brainShareEl) brainShareEl.parentNode.insertBefore(moreActionsEl, brainShareEl.nextSibling);
                     else if (moreActionsEl) rvPanelEl.parentNode.insertBefore(moreActionsEl, rvPanelEl.nextSibling);
+                    // Brain saves sits directly under moreActions so the
+                    // legacy single-slot Save Best+Restart button and the
+                    // new named-slot row are visually adjacent.
+                    if (brainSavesEl && moreActionsEl) moreActionsEl.parentNode.insertBefore(brainSavesEl, moreActionsEl.nextSibling);
                 }
+            } catch (_) {}
+            // Populate the brain-saves dropdown from localStorage now that
+            // the <select> exists in the DOM.
+            try {
+                if (typeof refreshBrainSavesDropdown === 'function') refreshBrainSavesDropdown();
             } catch (_) {}
             showInputCanvas();
             showGraphCanvas();

--- a/AI-Car-Racer/utils.js
+++ b/AI-Car-Racer/utils.js
@@ -188,6 +188,9 @@ function phaseToLayout(phase){
                     <div class='brain-saves-row'>
                         <button class='controlButton brain-saves-fresh' onclick='brainStartFresh();' title='Wipe ALL trained state (archive + saved best + fast lap) and reload — true gen-0 start. Named saves are preserved.'>🌱 Start with empty brain</button>
                     </div>
+                    <div class='brain-saves-row'>
+                        <button class='controlButton' onclick='clearAllFastLaps();' title='Wipe every per-track fast-lap record across all tracks. Named brain saves are NOT affected.'>🗑 Clear all fast laps</button>
+                    </div>
                 </div>
             </details>
             `;

--- a/docs/plan/ui-discoverability-pass.md
+++ b/docs/plan/ui-discoverability-pass.md
@@ -37,6 +37,24 @@ edits to `main.js` and `style.css`.
 | ✅ | B.2 | Brain-saves UI block in utils.js (`<details id='brainSaves'>` + dropdown + 4 buttons) | Claude | PR #2 | 2026-04-24 |
 | ✅ | B.3 | Smoke harness `tests/brain-saves-smoke.html` (6/6 PASS) + agent-browser validate | Claude | PR #2 | 2026-04-24 |
 
+**Follow-up: track-aware fast lap (FL.* below) shipped on the same branch (PR #2):**
+
+| Status | ID | Task | Owner | PR/SHA | Done date |
+|:--:|:--:|------|-------|--------|-----------|
+| ✅ | FL.1 | `hashVec` alias in `archive/hash.js`; per-track plumbing in `main.js` (state, helpers, boot-sync, legacy retirement) | Claude | PR #2 | 2026-04-24 |
+| ✅ | FL.2 | Track-scope `resetFastLap`; `clearAllFastLaps` in `buttonResponse.js`; `🗑 Clear all fast laps` button wired in 🧠 Brain saves disclosure; new timer render layout (`Fast Lap` + `Last` + `all-time best` subscript) | Claude | PR #2 | 2026-04-24 |
+| ✅ | FL.3 | Smoke harness `tests/fastlap-track-aware-smoke.html` (7/7 PASS) + agent-browser validate | Claude | PR #2 | 2026-04-24 |
+
+The FL.* row makes Fast Lap track-aware — the global `localStorage.fastLap`
+became `localStorage.vv_fastlap_<trackHash>` per track (hash via `hashVec`,
+xxHash32 of the 512-d CNN track embedding). New panel layout: "Fast Lap:
+12.34s (this track)" / "Last: 14.10s" / "all-time best: 9.10s" (subscript
+suppressed when current track holds the all-time record). `Reset Fast Lap`
+clears CURRENT track only; the bulk option lives in Brain saves as
+`🗑 Clear all fast laps` with a confirm() dialog. Legacy `fastLap`
+localStorage key silently retired at boot — the old value was
+track-confused, clean cut is honest.
+
 The B.* row delivers a multi-slot named-save system on top of the existing
 single-slot Save Best+Restart / Restore Old Brain pair. Storage: localStorage
 keys `vv_brainsave_<name>`. Load reuses the existing seeding pathway

--- a/docs/plan/ui-discoverability-pass.md
+++ b/docs/plan/ui-discoverability-pass.md
@@ -1,0 +1,155 @@
+# UI discoverability pass for the RuLake-inspired features
+
+Plan date: 2026-04-24. Follows the RuLake-inspired feature roadmap
+(see `docs/plan/rulake-inspired-features.md`) and addresses the
+single largest UX weakness of that work: **three features ship with
+zero UI and are discoverable only by knowing a URL flag.**
+
+This is a focused pass, not a multi-phase roadmap — one consolidated
+PR, ~250 lines of change concentrated in `uiPanels.js` plus small
+edits to `main.js` and `style.css`.
+
+## Status tracker
+
+**Legend:** ⬜ todo · 🟡 in progress · ✅ done · 🚫 blocked · ⏸ deferred
+
+**Current focus:** Not started — waiting on user approval of this plan.
+**Last updated:** 2026-04-24
+
+| Status | ID | Task | Owner | PR/SHA | Done date |
+|:--:|:--:|------|-------|--------|-----------|
+| ⬜ | A.1 | Add `🧪 Experiments` disclosure panel scaffold |  |  |  |
+| ⬜ | A.2 | Migrate Federation checkbox into the panel |  |  |  |
+| ⬜ | A.3 | Migrate Consistency modes radio row into the panel |  |  |  |
+| ⬜ | A.4 | Migrate Observability panel toggle into the panel |  |  |  |
+| ⬜ | A.5 | Un-gate Snapshot / share row (remove `?snapshots=1` requirement for UI render) |  |  |  |
+| ⬜ | A.6 | Un-gate Cross-tab row (remove `?crosstab=1` requirement for UI render) |  |  |  |
+| ⬜ | A.7 | Add disabled Quantization row with tooltip |  |  |  |
+| ⬜ | A.8 | Add `confirm()` on destructive Import action |  |  |  |
+| ⬜ | A.9 | `[Learn]` links next to each row → open matching ELI15 chapter |  |  |  |
+| ⬜ | A.10 | Smoke-test via agent-browser + commit |  |  |  |
+
+**Exit gate:** all rows ✅ + agent-browser smoke:
+- default URL: Experiments panel visible (collapsed), no behaviour change vs pre-pass;
+- expanding the panel shows 6 rows (snapshots, crosstab, federation, consistency, observability, quantization-disabled);
+- each `[Learn]` link opens the right chapter;
+- URL flags still work as presets (checkbox/radio pre-selected).
+
+---
+
+## What's wrong today
+
+Summary of current state (post RuLake roadmap, commit `ee2dd34`):
+
+| Feature | UI today | Problem |
+|---------|----------|---------|
+| Warm-restart Export / Import (F3) | Hidden — requires `?snapshots=1` to render at all | A user can train for an hour and not know they can save it |
+| Shareable archive URL + gallery (F3/3C) | Hidden — requires `?snapshots=1` | Can't share what you can't see |
+| Cross-tab live training (F6) | Hidden — requires `?crosstab=1` | The two-tab demo is delightful but completely undiscoverable |
+| Federation (F2) | Visible checkbox in training panel | ✅ Already correct — flag is a preset, not a gate |
+| Consistency modes (F4) | Visible radio row in training panel | ✅ Already correct |
+| Observability panel (F7) | Visible collapsed panel below training UI | ✅ Already correct (telemetry-only) |
+| 1-bit quantization (F1) | No UI — library-only | Invisible to users; chapter references nothing clickable |
+
+The pattern the three correct ones use is: **URL flag presets the initial state of a UI control that is always visible.** The three wrong ones gate the UI itself on the flag — no flag = no UI = no discoverability.
+
+## What this pass does
+
+### Design call: a single `🧪 Experiments` disclosure panel
+
+Rather than scatter five more toggle rows across the existing training panel (which is already dense), consolidate all feature toggles into one collapsible disclosure panel near the bottom of the training UI. Collapsed by default to keep the first-impression UI clean; expanded by one click when the user wants to explore.
+
+Shape (inside the panel, when expanded):
+
+```
+🧪 Experiments ▼
+  [Each row: toggle · emoji + label · one-line hint · (Learn →)]
+
+  ☐ 📦 Save & share archives            (Learn →)
+     Export your archive, import a shared one.
+  ☐ 🔗 Cross-tab live training          (Learn →)
+     Open two tabs — brains travel between them.
+  ☐ 🌐 Federated search                 (Learn →)
+     Union Euclidean + Hyperbolic nearest-neighbours.
+  🔘 Consistency: (•) Fresh  ( ) Eventual  ( ) Frozen   (Learn →)
+     How retrieval sees the archive as it grows.
+  ☑ ⏱ Per-stage timings panel           (Learn →)
+     Flame-graph-lite for each generation.
+  ☐ 📐 1-bit quantized archive (library-only; not wired yet)  (Learn →)
+     [disabled — tooltip: "Module ships but is not wired to archiveBrain yet"]
+```
+
+### Default state per feature
+
+| Feature | Default | Rationale |
+|---------|---------|-----------|
+| Snapshots / share | **OFF** | Adds file I/O + optional network fetches; opt-in semantically |
+| Cross-tab | **OFF** | Adds BroadcastChannel traffic + per-tab peer discovery |
+| Federation | **OFF** | Behaviour change (dual-index union) |
+| Consistency | **Fresh** | Zero behaviour delta vs pre-pass |
+| Observability | **ON** | Telemetry-only; already default-on today |
+| Quantization | **DISABLED** | Library-only; no backing integration |
+
+Preserves the rule: plain URL → plain behaviour.
+
+### URL flags keep working as presets
+
+Every existing flag (`?snapshots=1`, `?consistency=frozen`, `?federation=1`, `?crosstab=1`, `?archive=<url>`) continues to work, but now it presets the initial state of the corresponding UI control instead of gating whether the control renders. Shareable demo links unchanged.
+
+### Destructive-action guardrail
+
+Enabling **📦 Save & share archives** reveals the Export / Import / Share buttons. Clicking *Import* currently replaces the live archive without confirmation (previously OK because `?snapshots=1` was the friction; with the UI unhidden, that friction is gone). Add a `confirm()` on Import: *"This will replace your current N brains with the imported archive. Continue?"* The confirmation is the missing friction.
+
+### `[Learn]` links
+
+Each row's *Learn* link invokes `window.ELI15.openChapter(id)` with the matching chapter id. Turns the panel into a self-teaching surface — clicking *Learn* on federation opens the federation chapter, which has a live formula and a *"Try it yourself"* section that now points to the toggle one tap away in the panel.
+
+---
+
+## Files touched (scope-bounded)
+
+Expected diff, ~250 lines:
+
+- `AI-Car-Racer/uiPanels.js` — bulk of the work. Create `mountExperimentsPanel()` that renders the disclosure section. Move/refactor existing Federation + Consistency + Observability rows into it. Un-gate the Snapshots row (currently behind `if (usp.get('snapshots') === '1')`) and the Cross-tab row (currently behind `if (usp.get('crosstab') === '1')`). Anchored clearly so future edits don't collide.
+- `AI-Car-Racer/style.css` — styles for `.rv-experiments-panel` (disclosure + row + learn link + disabled row).
+- `AI-Car-Racer/main.js` — minor change: the URL-flag appliers currently call `setConsistencyMode()` / `setFederationEnabled()` / `setCrosstabEnabled()` regardless of UI state. Ensure each one also updates the UI control so the checkbox/radio reflects the actual bridge state after the preset applies. Small bug-fix-sized edits.
+- `tests/experiments-panel-smoke.html` (new) — standalone harness:
+  1. Load the main page, wait for panel scaffold.
+  2. Assert the disclosure starts collapsed.
+  3. Click disclosure; assert 6 rows visible.
+  4. Click *Learn* on a row; assert the ELI15 drawer opens with the right chapter.
+  5. Click a toggle; assert the corresponding bridge getter reports the new state.
+  6. Set `?snapshots=1` in URL; assert the Snapshots row is pre-toggled ON at boot.
+  Prints PASS/FAIL per claim.
+
+## Files NOT touched
+
+- None of the feature modules (`archive/`, `consistency/`, `quantization/`, `federation/`, `crosstab/`, `observability/`, `share/`, `lineage/`). This is pure UI plumbing over the existing APIs.
+- `ruvectorBridge.js` — no new exports; consumes existing setters/getters only.
+- Any existing ELI15 chapter body — the pass only touches the ordering + the way the panel links to chapters, not the content.
+
+## Exit criteria (the `/ship-task` gate)
+
+1. Default URL: Experiments panel appears collapsed; plain behaviour unchanged (every feature matches pre-pass default).
+2. Expanding the panel shows 6 rows in the order above.
+3. Every `[Learn]` link opens the correct ELI15 chapter via `window.ELI15.openChapter(id)`.
+4. Toggling each row changes the bridge state (verified via `window.__rvBridge` getters — isFederationEnabled, isCrosstabEnabled, getConsistencyMode, etc.).
+5. URL flags still work as presets — at boot, every flag that was set pre-selects its UI control.
+6. Import button shows a `confirm()` that mentions the live archive count.
+7. Quantization row renders disabled with a tooltip explaining the limitation.
+8. `tests/experiments-panel-smoke.html` PASS on all 6 claims.
+9. No new console errors at boot.
+
+## Trade-offs I'm making
+
+- **Visual simplicity over rich custom widgets.** Using the native `<details>` element + native checkboxes/radios rather than custom animated components. Ships faster, reads better for learners, one fewer thing to style.
+- **One panel over five separate UI sections.** Alternative is to put each feature's toggle in-context (e.g. cross-tab pill always visible next to the fps counter). Rejected because the main training panel is already dense — a single disclosure absorbs the new surface area in one place a user can choose to ignore or explore.
+- **No default-on flips.** I explicitly do NOT turn on Federation, Cross-tab, Snapshots, or Quantization by default, even though they're stable. Keeps the change a UX pass, not a behaviour change — if later we want "Federation default-on," that's a separate call backed by recall-vs-latency evidence per the cross-track-variance memory.
+
+## What this is NOT
+
+- Not a rewrite of any feature module.
+- Not a redesign of the training panel.
+- Not integrating quantization into the archive (that's a separate future slice).
+- Not adding new URL flags.
+- Not publishing any real archive URL to the community gallery (still gated by external-scope approval).

--- a/docs/plan/ui-discoverability-pass.md
+++ b/docs/plan/ui-discoverability-pass.md
@@ -29,6 +29,23 @@ edits to `main.js` and `style.css`.
 | ✅ | A.9 | `[Learn]` links next to each row → open matching ELI15 chapter | Claude | PR #2 | 2026-04-24 |
 | ✅ | A.10 | Smoke-test via agent-browser + commit | Claude | PR #2 | 2026-04-24 |
 
+**Follow-up: brain saves (B.* below) shipped on the same branch (PR #2):**
+
+| Status | ID | Task | Owner | PR/SHA | Done date |
+|:--:|:--:|------|-------|--------|-----------|
+| ✅ | B.1 | Brain-saves handlers in buttonResponse.js (Save / Load / Delete / Start Fresh + dropdown enumerate) | Claude | PR #2 | 2026-04-24 |
+| ✅ | B.2 | Brain-saves UI block in utils.js (`<details id='brainSaves'>` + dropdown + 4 buttons) | Claude | PR #2 | 2026-04-24 |
+| ✅ | B.3 | Smoke harness `tests/brain-saves-smoke.html` (6/6 PASS) + agent-browser validate | Claude | PR #2 | 2026-04-24 |
+
+The B.* row delivers a multi-slot named-save system on top of the existing
+single-slot Save Best+Restart / Restore Old Brain pair. Storage: localStorage
+keys `vv_brainsave_<name>`. Load reuses the existing seeding pathway
+(write to `localStorage.bestBrain` + `restartBatch()`). Start Fresh reuses
+`bridge._debugReset()` + clears legacy keys + reloads — but **preserves
+named saves** so the user's curated slots survive a reset. The 🌱 Start
+button is amber-tinted to visually distinguish it from the cheaper Reset
+Brain button.
+
 **Implementation notes:**
 - Refactor strategy was **wrap-don't-rebuild**: the existing consistency, federation, and crosstab DOM nodes are appended into the disclosure body via `appendChild`, which preserves every event listener and `el.X` reference established earlier in the file. No event re-binding required.
 - Disclosure auto-opens whenever ANY URL flag is set (`?snapshots=1`, `?crosstab=1`, `?federation=1`, `?consistency=*`, `?archive=*`) so a user opening a share link immediately sees what's enabled.

--- a/docs/plan/ui-discoverability-pass.md
+++ b/docs/plan/ui-discoverability-pass.md
@@ -13,21 +13,28 @@ edits to `main.js` and `style.css`.
 
 **Legend:** ⬜ todo · 🟡 in progress · ✅ done · 🚫 blocked · ⏸ deferred
 
-**Current focus:** Not started — waiting on user approval of this plan.
+**Current focus:** Implementation complete; pending PR #2 review/merge.
 **Last updated:** 2026-04-24
 
 | Status | ID | Task | Owner | PR/SHA | Done date |
 |:--:|:--:|------|-------|--------|-----------|
-| ⬜ | A.1 | Add `🧪 Experiments` disclosure panel scaffold |  |  |  |
-| ⬜ | A.2 | Migrate Federation checkbox into the panel |  |  |  |
-| ⬜ | A.3 | Migrate Consistency modes radio row into the panel |  |  |  |
-| ⬜ | A.4 | Migrate Observability panel toggle into the panel |  |  |  |
-| ⬜ | A.5 | Un-gate Snapshot / share row (remove `?snapshots=1` requirement for UI render) |  |  |  |
-| ⬜ | A.6 | Un-gate Cross-tab row (remove `?crosstab=1` requirement for UI render) |  |  |  |
-| ⬜ | A.7 | Add disabled Quantization row with tooltip |  |  |  |
-| ⬜ | A.8 | Add `confirm()` on destructive Import action |  |  |  |
-| ⬜ | A.9 | `[Learn]` links next to each row → open matching ELI15 chapter |  |  |  |
-| ⬜ | A.10 | Smoke-test via agent-browser + commit |  |  |  |
+| ✅ | A.1 | Add `🧪 Experiments` disclosure panel scaffold | Claude | PR #2 | 2026-04-24 |
+| ✅ | A.2 | Migrate Federation checkbox into the panel | Claude | PR #2 | 2026-04-24 |
+| ✅ | A.3 | Migrate Consistency modes radio row into the panel | Claude | PR #2 | 2026-04-24 |
+| ✅ | A.4 | Migrate Observability panel toggle into the panel | Claude | PR #2 | 2026-04-24 |
+| ✅ | A.5 | Un-gate Snapshot / share row (remove `?snapshots=1` requirement for UI render) | Claude | PR #2 | 2026-04-24 |
+| ✅ | A.6 | Un-gate Cross-tab row (remove `?crosstab=1` requirement for UI render) | Claude | PR #2 | 2026-04-24 |
+| ✅ | A.7 | Add disabled Quantization row with tooltip | Claude | PR #2 | 2026-04-24 |
+| ✅ | A.8 | Add `confirm()` on destructive Import action | Claude | PR #2 | 2026-04-24 |
+| ✅ | A.9 | `[Learn]` links next to each row → open matching ELI15 chapter | Claude | PR #2 | 2026-04-24 |
+| ✅ | A.10 | Smoke-test via agent-browser + commit | Claude | PR #2 | 2026-04-24 |
+
+**Implementation notes:**
+- Refactor strategy was **wrap-don't-rebuild**: the existing consistency, federation, and crosstab DOM nodes are appended into the disclosure body via `appendChild`, which preserves every event listener and `el.X` reference established earlier in the file. No event re-binding required.
+- Disclosure auto-opens whenever ANY URL flag is set (`?snapshots=1`, `?crosstab=1`, `?federation=1`, `?consistency=*`, `?archive=*`) so a user opening a share link immediately sees what's enabled.
+- Crosstab listeners are now wired unconditionally (previously gated by `?crosstab=1`); the experiments toggle drives `setCrosstabEnabled` rather than render-time gating.
+- Smoke harness uses two hidden iframes — one no-flag, one `?snapshots=1` — to test default state AND preset behaviour in a single page.
+- 7/7 harness PASS including the cross-feature claim that toggling the crosstab checkbox flips the bridge's `isCrosstabEnabled()` from false to true (proves UI-to-bridge coupling, not just visual).
 
 **Exit gate:** all rows ✅ + agent-browser smoke:
 - default URL: Experiments panel visible (collapsed), no behaviour change vs pre-pass;

--- a/tests/brain-saves-smoke.html
+++ b/tests/brain-saves-smoke.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Brain saves smoke (Phase A)</title>
+  <style>
+    body { font: 14px ui-monospace, monospace; background: #0e1422; color: #e6ebfa; padding: 18px; }
+    h1 { font-size: 18px; margin: 0 0 8px; }
+    p  { color: #8a98be; margin: 4px 0 14px; }
+    .ok   { color: #62f0b8; }
+    .fail { color: #f08080; font-weight: 700; }
+    table { border-collapse: collapse; width: 100%; }
+    td, th { padding: 4px 8px; border-bottom: 1px solid rgba(120,140,200,0.18); vertical-align: top; }
+    pre { white-space: pre-wrap; color: #cbd8ff; font-size: 12px; margin: 2px 0 0; }
+  </style>
+</head>
+<body>
+  <h1>Brain saves smoke (Phase A)</h1>
+  <p>
+    Exercises the named brain-save primitives in <code>buttonResponse.js</code>
+    (<code>vv_brainsave_*</code> localStorage keys). Tests are confined to
+    primitives that don't require <code>confirm()</code> dialogs —
+    specifically the <strong>byte-identity round-trip</strong> claim
+    (a saved brain reads back equal to the original) and the dropdown
+    enumeration. The confirm-bearing paths (Load / Delete / Start Fresh)
+    are trivial wrappers over these primitives plus an existing
+    <code>localStorage.setItem('bestBrain', ...)</code> + <code>restartBatch()</code>
+    pathway, verified by code review.
+  </p>
+
+  <div id="verdict">running…</div>
+
+  <h2 style="margin-top:18px;font-size:14px;">Claims</h2>
+  <table id="claims">
+    <thead><tr><th>#</th><th>claim</th><th>verdict</th><th>detail</th></tr></thead>
+    <tbody></tbody>
+  </table>
+
+  <!-- Provide the dropdown the handlers expect -->
+  <div style="visibility:hidden;height:0;overflow:hidden">
+    <select id="brainSavesSelect"><option value="" disabled selected>(no saves yet)</option></select>
+  </div>
+
+  <script>
+    // Globals buttonResponse.js's brain-saves block reads (refreshBrainSavesDropdown
+    // touches localStorage only; no DOM-state surprises).
+    window.__rvSessionBestFitness = 42.5;
+    window.lastEmbeddedTrackId = 'rect-test';
+  </script>
+  <script src="../AI-Car-Racer/buttonResponse.js"></script>
+  <script>
+    const claims = [];
+    const tbody = document.querySelector('#claims tbody');
+    const verdictEl = document.querySelector('#verdict');
+    function record(label, ok, detail) {
+      claims.push({ label, ok, detail });
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${claims.length}</td><td>${label}</td><td class="${ok ? 'ok' : 'fail'}">${ok ? 'PASS' : 'FAIL'}</td><td><pre>${typeof detail === 'string' ? detail : JSON.stringify(detail, null, 2)}</pre></td>`;
+      tbody.appendChild(tr);
+    }
+    function clearAllSaves() {
+      for (let i = localStorage.length - 1; i >= 0; i--) {
+        const k = localStorage.key(i);
+        if (k && k.indexOf('vv_brainsave_') === 0) localStorage.removeItem(k);
+      }
+    }
+
+    try {
+      clearAllSaves();
+
+      // C1 — Round-trip byte-identity. The load path writes
+      // JSON.stringify(slot.brain) into localStorage.bestBrain. Verify
+      // that for any slot we seed, JSON.parse(JSON.stringify(slot.brain))
+      // is byte-identical to the original — i.e. the load path can
+      // reproduce the saved brain exactly.
+      const originalBrain = { levels: [
+        { biases: [0.1, -0.2, 0.3, 0.4], weights: [[0.5, -0.6], [0.7, 0.8]] },
+        { biases: [-0.9, 1.0], weights: [[1.1], [-1.2]] },
+      ] };
+      const slot = { name: 'rt', savedAt: '2026-04-24T18:00:00Z', fitness: 42.5, trackId: 'rect', brain: originalBrain };
+      localStorage.setItem('vv_brainsave_rt', JSON.stringify(slot));
+      const decoded = JSON.parse(localStorage.getItem('vv_brainsave_rt'));
+      const reSerializedBrain = JSON.stringify(decoded.brain);
+      const expectedBrain = JSON.stringify(originalBrain);
+      record('1. Save → reload → JSON byte-identity of brain payload',
+        reSerializedBrain === expectedBrain,
+        { equal: reSerializedBrain === expectedBrain, slotKeys: Object.keys(decoded), brainShape: Object.keys(decoded.brain) });
+
+      // C2 — refreshBrainSavesDropdown enumerates pre-seeded keys
+      localStorage.setItem('vv_brainsave_alpha', JSON.stringify({ name: 'alpha', brain: { levels: [{ biases: [1], weights: [[1]] }] }, fitness: 10 }));
+      localStorage.setItem('vv_brainsave_beta',  JSON.stringify({ name: 'beta',  brain: { levels: [{ biases: [9], weights: [[9]] }] }, fitness: 99 }));
+      refreshBrainSavesDropdown();
+      const sel = document.getElementById('brainSavesSelect');
+      const opts = Array.from(sel.options).map(o => o.value);
+      record('2. refreshBrainSavesDropdown enumerates vv_brainsave_* keys + decorates with fitness',
+        opts.includes('rt') && opts.includes('alpha') && opts.includes('beta') &&
+        Array.from(sel.options).some(o => /fit\s*99/.test(o.textContent)),
+        { optionValues: opts, sampleText: Array.from(sel.options).map(o => o.textContent) });
+
+      // C3 — Multi-slot distinct content
+      const a = JSON.parse(localStorage.getItem('vv_brainsave_alpha'));
+      const b = JSON.parse(localStorage.getItem('vv_brainsave_beta'));
+      record('3. Multi-slot coexistence: distinct content per name',
+        a && b && JSON.stringify(a.brain) !== JSON.stringify(b.brain),
+        { alphaBias0: a?.brain?.levels?.[0]?.biases?.[0], betaBias0: b?.brain?.levels?.[0]?.biases?.[0] });
+
+      // C4 — Direct simulation of brainSaveLoad's storage write (the
+      // confirm-bearing wrapper just gates this with a y/n prompt).
+      // Verify that copying a slot's brain into localStorage.bestBrain
+      // produces a value byte-identical to JSON.stringify(slot.brain).
+      const slotForLoad = JSON.parse(localStorage.getItem('vv_brainsave_alpha'));
+      localStorage.setItem('bestBrain', JSON.stringify(slotForLoad.brain));
+      const bestBrainAfter = localStorage.getItem('bestBrain');
+      record('4. Load primitive: localStorage.bestBrain ← JSON.stringify(slot.brain)',
+        bestBrainAfter === JSON.stringify(slotForLoad.brain),
+        { byteIdentical: bestBrainAfter === JSON.stringify(slotForLoad.brain), len: bestBrainAfter?.length });
+
+      // C5 — Delete primitive: remove a vv_brainsave_<name> key without
+      // touching the others.
+      localStorage.removeItem('vv_brainsave_alpha');
+      record('5. Delete primitive: removeItem affects only the named slot',
+        localStorage.getItem('vv_brainsave_alpha') === null &&
+        localStorage.getItem('vv_brainsave_beta') !== null &&
+        localStorage.getItem('vv_brainsave_rt') !== null,
+        {
+          alphaAfter: localStorage.getItem('vv_brainsave_alpha'),
+          betaSurvived: !!localStorage.getItem('vv_brainsave_beta'),
+          rtSurvived: !!localStorage.getItem('vv_brainsave_rt'),
+        });
+
+      // C6 — Verify the handlers exist as globals (sanity check that
+      // buttonResponse.js loaded and exposed the new functions).
+      record('6. brainSaveAs / brainSaveLoad / brainSaveDelete / brainStartFresh / refreshBrainSavesDropdown all defined',
+        typeof brainSaveAs === 'function' &&
+        typeof brainSaveLoad === 'function' &&
+        typeof brainSaveDelete === 'function' &&
+        typeof brainStartFresh === 'function' &&
+        typeof refreshBrainSavesDropdown === 'function',
+        {
+          brainSaveAs: typeof brainSaveAs,
+          brainSaveLoad: typeof brainSaveLoad,
+          brainSaveDelete: typeof brainSaveDelete,
+          brainStartFresh: typeof brainStartFresh,
+          refreshBrainSavesDropdown: typeof refreshBrainSavesDropdown,
+        });
+
+    } catch (e) {
+      record('harness error', false, String(e && e.stack || e));
+    } finally {
+      clearAllSaves();
+      localStorage.removeItem('bestBrain');
+      const passed = claims.filter(c => c.ok).length;
+      const total = claims.length;
+      verdictEl.className = passed === total ? 'ok' : 'fail';
+      verdictEl.textContent = passed === total
+        ? `PASS — ${passed}/${total} claims hold.`
+        : `FAIL — ${passed}/${total} claims hold.`;
+    }
+  </script>
+</body>
+</html>

--- a/tests/experiments-panel-smoke.html
+++ b/tests/experiments-panel-smoke.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Experiments panel smoke (Phase A)</title>
+  <style>
+    body { font: 14px ui-monospace, monospace; background: #0e1422; color: #e6ebfa; padding: 18px; }
+    h1 { font-size: 18px; margin: 0 0 8px; }
+    p  { color: #8a98be; margin: 4px 0 14px; }
+    .ok   { color: #62f0b8; }
+    .fail { color: #f08080; font-weight: 700; }
+    table { border-collapse: collapse; width: 100%; }
+    td, th { padding: 4px 8px; border-bottom: 1px solid rgba(120,140,200,0.18); vertical-align: top; }
+    pre { white-space: pre-wrap; color: #cbd8ff; font-size: 12px; margin: 2px 0 0; }
+    iframe { display: none; }
+  </style>
+</head>
+<body>
+  <h1>Experiments panel smoke (Phase A)</h1>
+  <p>
+    Loads <code>../AI-Car-Racer/index.html</code> in a hidden iframe and
+    asserts UI claims. The plain URL load tests default state; a second
+    iframe loads with <code>?snapshots=1</code> to verify the URL flag
+    presets the corresponding toggle.
+  </p>
+
+  <div id="verdict">running…</div>
+
+  <h2 style="margin-top: 18px; font-size: 14px;">Claims</h2>
+  <table id="claims">
+    <thead><tr><th>#</th><th>claim</th><th>verdict</th><th>detail</th></tr></thead>
+    <tbody></tbody>
+  </table>
+
+  <iframe id="ifr-default" src="../AI-Car-Racer/index.html"></iframe>
+  <iframe id="ifr-flag" src="../AI-Car-Racer/index.html?snapshots=1"></iframe>
+
+  <script type="module">
+    const claims = [];
+
+    const tbody = document.querySelector('#claims tbody');
+    const verdictEl = document.querySelector('#verdict');
+
+    function record(label, ok, detail) {
+      claims.push({ label, ok, detail });
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${claims.length}</td><td>${label}</td><td class="${ok ? 'ok' : 'fail'}">${ok ? 'PASS' : 'FAIL'}</td><td><pre>${typeof detail === 'string' ? detail : JSON.stringify(detail, null, 2)}</pre></td>`;
+      tbody.appendChild(tr);
+    }
+
+    async function waitForIframe(ifr, ms = 6000) {
+      const start = Date.now();
+      while (Date.now() - start < ms) {
+        try {
+          const w = ifr.contentWindow;
+          const d = ifr.contentDocument;
+          if (w && d && d.querySelector('[data-rv="experiments"]')) return { w, d };
+        } catch (_) {}
+        await new Promise(r => setTimeout(r, 100));
+      }
+      throw new Error('iframe did not load experiments panel within ' + ms + 'ms');
+    }
+
+    function summarize() {
+      const passed = claims.filter(c => c.ok).length;
+      const total = claims.length;
+      verdictEl.className = passed === total ? 'ok' : 'fail';
+      verdictEl.textContent = passed === total
+        ? `PASS — ${passed}/${total} claims hold.`
+        : `FAIL — ${passed}/${total} claims hold.`;
+    }
+
+    try {
+      // === Default URL: no flags ===
+      const ifrDefault = document.getElementById('ifr-default');
+      const { d: dDef, w: wDef } = await waitForIframe(ifrDefault);
+
+      // C1 — disclosure exists, defaults closed
+      const details = dDef.querySelector('[data-rv="experiments"]');
+      record('1. Experiments disclosure exists, defaults closed', !!details && !details.open, {
+        present: !!details,
+        open: details ? details.open : null,
+      });
+
+      // C2 — opening reveals 6 rows (5 + 1 disabled)
+      details.open = true;
+      await new Promise(r => setTimeout(r, 50));
+      const rows = details.querySelectorAll('.rv-experiments-row');
+      record('2. 6 rows visible after expand (incl. disabled quantization)', rows.length === 6, {
+        rowCount: rows.length,
+        ids: Array.from(rows).map(r => r.getAttribute('data-rv')),
+      });
+
+      // C3 — quantization row is disabled
+      const quantInput = details.querySelector('[data-rv="exp-quantization-row"] input');
+      record('3. Quantization row is disabled (library-only)', quantInput && quantInput.disabled, {
+        disabled: quantInput ? quantInput.disabled : null,
+      });
+
+      // C4 — Learn badges present on each new row
+      const learnIds = ['where-the-time-goes', 'warm-restart', 'cross-tab-federation', 'quantization'];
+      const learnPresent = learnIds.every(id => !!details.querySelector(`[data-eli15="${id}"]`));
+      record('4. [Learn] eli15 badges wired on new rows', learnPresent, { learnIds });
+
+      // C5 — snapshots subbody hidden by default; toggling checkbox reveals it
+      const snapshotsCb = details.querySelector('[data-rv="exp-snapshots"]');
+      const snapshotsSub = details.querySelector('[data-rv="exp-snapshots-subbody"]');
+      const beforeHidden = snapshotsSub.hidden;
+      snapshotsCb.checked = true;
+      snapshotsCb.dispatchEvent(new Event('change'));
+      await new Promise(r => setTimeout(r, 50));
+      const afterHidden = snapshotsSub.hidden;
+      record('5. Snapshots toggle gates the inner controls', beforeHidden === true && afterHidden === false, {
+        beforeHidden, afterHidden,
+        snapshotsRowChild: !!snapshotsSub.querySelector('[data-rv="snapshots"]'),
+        shareRowChild:    !!snapshotsSub.querySelector('[data-rv="share"]'),
+      });
+
+      // C6 — crosstab toggle drives the bridge state
+      const crosstabCb = details.querySelector('[data-rv="exp-crosstab"]');
+      const bridge = wDef.__rvBridge;
+      const beforeEnabled = bridge && bridge.isCrosstabEnabled ? bridge.isCrosstabEnabled() : null;
+      crosstabCb.checked = true;
+      crosstabCb.dispatchEvent(new Event('change'));
+      await new Promise(r => setTimeout(r, 100));
+      const afterEnabled = bridge && bridge.isCrosstabEnabled ? bridge.isCrosstabEnabled() : null;
+      record('6. Crosstab toggle drives bridge.setCrosstabEnabled', beforeEnabled === false && afterEnabled === true, {
+        beforeEnabled, afterEnabled,
+      });
+
+      // === ?snapshots=1 URL flag ===
+      const ifrFlag = document.getElementById('ifr-flag');
+      const { d: dFlag } = await waitForIframe(ifrFlag);
+      const detailsFlag = dFlag.querySelector('[data-rv="experiments"]');
+      const snapshotsCbFlag = detailsFlag.querySelector('[data-rv="exp-snapshots"]');
+      const snapshotsSubFlag = detailsFlag.querySelector('[data-rv="exp-snapshots-subbody"]');
+      record('7. ?snapshots=1 presets the toggle ON at boot + reveals controls', snapshotsCbFlag.checked === true && snapshotsSubFlag.hidden === false, {
+        flagToggleChecked: snapshotsCbFlag.checked,
+        flagSubbodyHidden: snapshotsSubFlag.hidden,
+        flagDetailsOpen:   detailsFlag.open,
+      });
+
+    } catch (e) {
+      record('harness setup', false, String(e && e.stack || e));
+    } finally {
+      summarize();
+    }
+  </script>
+</body>
+</html>

--- a/tests/fastlap-track-aware-smoke.html
+++ b/tests/fastlap-track-aware-smoke.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Fast-lap track-aware smoke (Phase A)</title>
+  <style>
+    body { font: 14px ui-monospace, monospace; background: #0e1422; color: #e6ebfa; padding: 18px; }
+    h1 { font-size: 18px; margin: 0 0 8px; }
+    p  { color: #8a98be; margin: 4px 0 14px; }
+    .ok   { color: #62f0b8; }
+    .fail { color: #f08080; font-weight: 700; }
+    table { border-collapse: collapse; width: 100%; }
+    td, th { padding: 4px 8px; border-bottom: 1px solid rgba(120,140,200,0.18); vertical-align: top; }
+    pre { white-space: pre-wrap; color: #cbd8ff; font-size: 12px; margin: 2px 0 0; }
+  </style>
+</head>
+<body>
+  <h1>Fast-lap track-aware smoke (Phase A)</h1>
+  <p>
+    Exercises the per-track fast-lap storage primitives. Imports
+    <code>archive/hash.js</code> directly to verify hash determinism,
+    then drives <code>localStorage</code> with the
+    <code>vv_fastlap_&lt;trackHash&gt;</code> shape used by
+    <code>main.js</code>. Also confirms the legacy <code>fastLap</code>
+    key retirement leaves the per-track keys alone.
+  </p>
+
+  <div id="verdict">running…</div>
+
+  <h2 style="margin-top:18px;font-size:14px;">Claims</h2>
+  <table id="claims">
+    <thead><tr><th>#</th><th>claim</th><th>verdict</th><th>detail</th></tr></thead>
+    <tbody></tbody>
+  </table>
+
+  <script type="module">
+    import { hashVec, hashBrain } from '../AI-Car-Racer/archive/hash.js';
+
+    const claims = [];
+    const tbody = document.querySelector('#claims tbody');
+    const verdictEl = document.querySelector('#verdict');
+    function record(label, ok, detail) {
+      claims.push({ label, ok, detail });
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${claims.length}</td><td>${label}</td><td class="${ok ? 'ok' : 'fail'}">${ok ? 'PASS' : 'FAIL'}</td><td><pre>${typeof detail === 'string' ? detail : JSON.stringify(detail, null, 2)}</pre></td>`;
+      tbody.appendChild(tr);
+    }
+
+    const PREFIX = 'vv_fastlap_';
+    function clearAll() {
+      for (let i = localStorage.length - 1; i >= 0; i--) {
+        const k = localStorage.key(i);
+        if (k && (k.indexOf(PREFIX) === 0 || k === 'fastLap')) localStorage.removeItem(k);
+      }
+    }
+    function makeTrackVec(seed) {
+      // Mimic the 512-d Float32 CNN embedding shape; deterministic per seed.
+      const v = new Float32Array(512);
+      let x = seed | 0;
+      for (let i = 0; i < 512; i++) {
+        x = (Math.imul(x, 1664525) + 1013904223) | 0;
+        v[i] = (x / 0x7fffffff);
+      }
+      return v;
+    }
+
+    try {
+      clearAll();
+
+      // C1 — hashVec is the same function as hashBrain (alias check)
+      record('1. hashVec is exported as an alias of hashBrain (same fn or same output)',
+        hashVec === hashBrain || (
+          hashVec(new Float32Array([1,2,3])) === hashBrain(new Float32Array([1,2,3]))
+        ),
+        { sameRef: hashVec === hashBrain });
+
+      // C2 — Determinism: same vec → same hash, twice
+      const v1 = makeTrackVec(42);
+      const v1again = makeTrackVec(42); // same seed → same content
+      const h1 = hashVec(v1);
+      const h1again = hashVec(v1again);
+      record('2. hashVec deterministic: identical input → byte-identical hash',
+        h1 === h1again && /^[0-9a-f]{8}$/.test(h1),
+        { hash: h1, equal: h1 === h1again, len: h1.length });
+
+      // C3 — Different vecs → different hashes (collision-free in practice)
+      const v2 = makeTrackVec(99);
+      const h2 = hashVec(v2);
+      record('3. Distinct vecs produce distinct hashes',
+        h1 !== h2,
+        { h1, h2 });
+
+      // C4 — Per-track segregation: writing a record under track-A
+      // doesn't surface under track-B's key, and vice versa.
+      const keyA = PREFIX + h1;
+      const keyB = PREFIX + h2;
+      localStorage.setItem(keyA, JSON.stringify({ timeS: 12.34, recordedAt: '2026-04-24T00:00:00Z', generation: 5 }));
+      localStorage.setItem(keyB, JSON.stringify({ timeS:  8.76, recordedAt: '2026-04-24T00:00:00Z', generation: 9 }));
+      const readA = JSON.parse(localStorage.getItem(keyA));
+      const readB = JSON.parse(localStorage.getItem(keyB));
+      record('4. Per-track segregation: each track\'s record reads back independently',
+        readA.timeS === 12.34 && readB.timeS === 8.76,
+        { trackA_time: readA.timeS, trackB_time: readB.timeS });
+
+      // C5 — All-time-best math: min over all vv_fastlap_* entries
+      let allBest = Infinity;
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (k && k.indexOf(PREFIX) === 0) {
+          const t = JSON.parse(localStorage.getItem(k)).timeS;
+          if (t < allBest) allBest = t;
+        }
+      }
+      record('5. all-time-best = min over per-track entries',
+        allBest === 8.76,
+        { allBest, expected: 8.76 });
+
+      // C6 — Legacy retirement: pre-existing localStorage.fastLap should be
+      // removable without disturbing per-track keys.
+      localStorage.setItem('fastLap', '17.5'); // simulate pre-upgrade state
+      // The retirement code in main.js does: localStorage.removeItem('fastLap')
+      localStorage.removeItem('fastLap');
+      record('6. Legacy fastLap key retirement leaves per-track records intact',
+        localStorage.getItem('fastLap') === null &&
+        localStorage.getItem(keyA) !== null &&
+        localStorage.getItem(keyB) !== null,
+        {
+          legacyAfter: localStorage.getItem('fastLap'),
+          trackAStillThere: !!localStorage.getItem(keyA),
+          trackBStillThere: !!localStorage.getItem(keyB),
+        });
+
+      // C7 — Clear-all primitive: remove every vv_fastlap_* key, leave others.
+      localStorage.setItem('vv_brainsave_unrelated', '{"keep":true}');
+      const toRemove = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (k && k.indexOf(PREFIX) === 0) toRemove.push(k);
+      }
+      toRemove.forEach(k => localStorage.removeItem(k));
+      record('7. Clear-all primitive removes vv_fastlap_* but spares vv_brainsave_*',
+        localStorage.getItem(keyA) === null &&
+        localStorage.getItem(keyB) === null &&
+        localStorage.getItem('vv_brainsave_unrelated') !== null,
+        {
+          trackARemoved: localStorage.getItem(keyA) === null,
+          trackBRemoved: localStorage.getItem(keyB) === null,
+          brainSaveSpared: !!localStorage.getItem('vv_brainsave_unrelated'),
+        });
+
+    } catch (e) {
+      record('harness error', false, String(e && e.stack || e));
+    } finally {
+      clearAll();
+      localStorage.removeItem('vv_brainsave_unrelated');
+      const passed = claims.filter(c => c.ok).length;
+      const total = claims.length;
+      verdictEl.className = passed === total ? 'ok' : 'fail';
+      verdictEl.textContent = passed === total
+        ? `PASS — ${passed}/${total} claims hold.`
+        : `FAIL — ${passed}/${total} claims hold.`;
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR contains a **plan document only** — no feature code. It
proposes a UI discoverability pass for the features landed in PR #1
(RuLake-inspired roadmap).

The core issue: three features (\`?snapshots=1\` save/share,
\`?crosstab=1\` cross-tab sync, and the library-only 1-bit
quantization) ship with zero UI — only discoverable by reading
docs or chapter text. Two other features (federation, consistency
modes) already use the right pattern: URL flag presets the initial
state of an always-visible UI control.

This plan proposes a single \`🧪 Experiments\` disclosure panel that:

1. Consolidates all feature toggles into one collapsible section at the bottom of the training panel.
2. Un-gates the currently-hidden snapshot/share and cross-tab rows — render always, default OFF, flag continues to work as a preset.
3. Adds a disabled row for 1-bit quantization with a tooltip explaining it's library-only.
4. Adds a \`confirm()\` guardrail on destructive Import actions.
5. Adds a \`[Learn]\` link per row that calls \`window.ELI15.openChapter(id)\`.

Scope is small: ~250 lines, one PR, primarily in \`AI-Car-Racer/uiPanels.js\`. No feature module is touched.

See \`docs/plan/ui-discoverability-pass.md\` for:
- 10-task checklist status tracker
- Default-state table per feature
- Exit criteria + harness requirements
- Design trade-offs (native \`<details>\` over custom widgets, one consolidated panel over scattered toggles, no default-on flips)

## Why plan-only first

Per the working discipline on this project, non-trivial UX
changes get a reviewable plan document before code. This PR is
the reviewable plan; the implementation PR will follow once the
plan is approved.

## What's NOT in this plan

- No new URL flags.
- No default-on flips (Federation, Cross-tab, Snapshots, Quantization all stay OFF by default).
- No redesign of the existing training panel.
- No integration of quantization into the archive hot path.
- No real community archive URLs published.

## Test plan

- [ ] Review \`docs/plan/ui-discoverability-pass.md\` end-to-end.
- [ ] Confirm the default-state table matches the roadmap's conservatism posture (plain URL = plain behaviour).
- [ ] Confirm the exit criteria are testable via agent-browser.
- [ ] Approve or request specific changes to the design calls (single-panel vs. scattered, default-off vs. default-on, native vs. custom widgets).

After approval, an implementation PR lands the actual ~250 lines + the \`tests/experiments-panel-smoke.html\` harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Experiments disclosure panel with toggles for Save & share archives, Cross-tab live training, and other experimental features
  * Previously hidden features are now discoverable in the UI; URL flags preset toggle states

* **Bug Fixes**
  * Import operations now display confirmation dialogs warning they will replace the current archive

<!-- end of auto-generated comment: release notes by coderabbit.ai -->